### PR TITLE
Install dev deps on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           elixir-version: '1.13.0'
           otp-version: '24.1'
 
+      - uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - run: mix deps.get
+
       - run: mix format --check-formatted
 
       - run: mix compile --warning-as-errors


### PR DESCRIPTION
Hustled to publish and now ci crashed. Let it install ex_doc. Never wanting it crash on main, check to see if it works in this PR.